### PR TITLE
Bump rune-dsl to 10.0.0-dev.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>10.0.0-dev.17</rune.dsl.version>
+        <rune.dsl.version>10.0.0-dev.19</rune.dsl.version>
         <rune.common.version>0.0.0.main-SNAPSHOT</rune.common.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/src/test/java/util/UnusedModelElementFinderTest.java
+++ b/src/test/java/util/UnusedModelElementFinderTest.java
@@ -52,8 +52,11 @@ public class UnusedModelElementFinderTest {
         UnusedModelElementFinder unusedModelElementFinder = new UnusedModelElementFinder(models);
 
         unusedModelElementFinder.run();
-        assertEquals(7, unusedModelElementFinder.getListOfTypes().size(), unusedModelElementFinder.getListOfTypes().toString());
+        // 8 includes the built-in com.rosetta.model.SerializationFormat enum (added in rune-dsl 10.0.0-dev.19),
+        // which is unused by this test model.
+        assertEquals(8, unusedModelElementFinder.getListOfTypes().size(), unusedModelElementFinder.getListOfTypes().toString());
 
+        assertTrue(unusedModelElementFinder.getListOfTypes().contains("com.rosetta.model.SerializationFormat"), "ListOfTypes should contain com.rosetta.model.SerializationFormat");
         assertTrue(unusedModelElementFinder.getListOfTypes().contains("cdm.test.Test1"), "ListOfTypes should contain cdm.test.Test1");
         assertTrue(unusedModelElementFinder.getListOfTypes().contains("cdm.test.Test2"), "ListOfTypes should contain cdm.test.Test2");
         assertTrue(unusedModelElementFinder.getListOfTypes().contains("cdm.test.Test3"),"ListOfTypes should contain cdm.test.Test3");
@@ -70,7 +73,9 @@ public class UnusedModelElementFinderTest {
         assertTrue(unusedModelElementFinder.getListOfUsedTypes().contains("cdm.test.TestEnum3UsedInFuncOnly"), "ListOfUsedTypes should contain cdm.test.TestEnum3UsedInFuncOnly");
 
 
-        assertEquals(2, unusedModelElementFinder.getListOfOrphanedTypes().size(), unusedModelElementFinder.getListOfOrphanedTypes().toString());
+        // 3 includes the built-in com.rosetta.model.SerializationFormat enum (added in rune-dsl 10.0.0-dev.19).
+        assertEquals(3, unusedModelElementFinder.getListOfOrphanedTypes().size(), unusedModelElementFinder.getListOfOrphanedTypes().toString());
+        assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("com.rosetta.model.SerializationFormat"), "ListOfOrphanedTypes should contain com.rosetta.model.SerializationFormat");
         assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("cdm.test.TestEnum2Unused"), "ListOfOrphanedTypes should contain cdm.test.TestEnum2Unused");
         assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("cdm.test.Test4Unused"), "ListOfOrphanedTypes should contain cdm.test.Test4Unused");
 


### PR DESCRIPTION
Bumps `rune.dsl.version` to `10.0.0-dev.19`.

## Changes
- `pom.xml`: `rune.dsl.version` 10.0.0-dev.17 -> 10.0.0-dev.19
- `UnusedModelElementFinderTest`: updated the expected counts for the new built-in `com.rosetta.model.SerializationFormat` enum shipped by dev.19 (it is reported as an unused/orphaned type by this test model). Pure test-expectation adjustment.

Minimal compat-only patch. No feature work. Builds green (default and `-Prelease -Dgpg.skip=true`).